### PR TITLE
Replace reset-fixed.css with fixed position container decorator

### DIFF
--- a/src/components/DailyTotal/DailyTotal.story.js
+++ b/src/components/DailyTotal/DailyTotal.story.js
@@ -3,14 +3,14 @@ import { storiesOf, withInfo } from '../../stories';
 
 import DailyTotal from './DailyTotal';
 
-import './reset-fixed.css';
+import fixedPositionContainer from '../../utils/fixedPositionContainer';
 
 storiesOf('DailyTotal')
+
+	.addDecorator(fixedPositionContainer(({ height: 100 })))
 
 	.addDecorator((story, context) => withInfo(DailyTotal.description)(story)(context))
 
 	.add('base', () => (
-		<div className="reset-fixed">
-			<DailyTotal total="123.45" symbol="GRM" />
-		</div>
+		<DailyTotal total="123.45" symbol="GRM" />
 	));

--- a/src/components/DailyTotal/reset-fixed.css
+++ b/src/components/DailyTotal/reset-fixed.css
@@ -1,6 +1,0 @@
-.reset-fixed {
-	/* Resets position:fixed; anchor */
-	transform: translate3d(0,0,0);
-	width: 100%;
-	height: 500px;
-}

--- a/src/components/SettingsDrawer/SettingsDrawer.story.js
+++ b/src/components/SettingsDrawer/SettingsDrawer.story.js
@@ -3,34 +3,32 @@ import { storiesOf, withInfo, action } from '../../stories';
 
 import SettingsDrawer from './SettingsDrawer';
 
-import './reset-fixed.css';
+import fixedPositionContainer from '../../utils/fixedPositionContainer';
 
 storiesOf('SettingsDrawer')
+
+	.addDecorator(fixedPositionContainer({ height: 600 }))
 
 	.addDecorator((story, context) => withInfo(SettingsDrawer.description)(story)(context))
 
 	.add('Open', () => (
-		<div className="reset-fixed">
-			<SettingsDrawer isOpen={true} onClose={action('onClose')}>
-				<ul>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-				</ul>
-			</SettingsDrawer>
-		</div>
+		<SettingsDrawer isOpen={true} onClose={action('onClose')}>
+			<ul>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+			</ul>
+		</SettingsDrawer>
 	))
 
 	.add('Closed', () => (
-		<div className="reset-fixed">
-			<SettingsDrawer isOpen={false} onClose={action('onClose')}>
-				<ul>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-					<li>Lorem ipsum dolor</li>
-				</ul>
-			</SettingsDrawer>
-		</div>
+		<SettingsDrawer isOpen={false} onClose={action('onClose')}>
+			<ul>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+				<li>Lorem ipsum dolor</li>
+			</ul>
+		</SettingsDrawer>
 	));

--- a/src/components/SettingsDrawer/reset-fixed.css
+++ b/src/components/SettingsDrawer/reset-fixed.css
@@ -1,6 +1,0 @@
-.reset-fixed {
-	/* Resets position:fixed; anchor */
-	transform: translate3d(0,0,0);
-	width: 100%;
-	height: 500px;
-}

--- a/src/utils/fixedPositionContainer.js
+++ b/src/utils/fixedPositionContainer.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const defaultStyles = {
+	transform: 'translateZ(0)',
+	width: '100%',
+	height: 500,
+};
+
+export default customStyles => {
+	const styles = {...defaultStyles, ...customStyles};
+
+	const fixedPositionContainer = story => <div style={styles}>{ story() }</div>;
+
+	return fixedPositionContainer;
+};


### PR DESCRIPTION
### Description

Replaces duplicated `reset-fixed.css` with a decorator for use in story definitions.

### Issues fixed

None.

### Checklist

- [x] `npm test` returns no warnings or errors.
