### PR TITLE
trust prop not required for transactions to display

### DIFF
--- a/src/components/TransactionsList/TransactionsList.js
+++ b/src/components/TransactionsList/TransactionsList.js
@@ -8,7 +8,8 @@ import CompletedTransactionsList from '../CompletedTransactionsList/CompletedTra
 
 const TransactionsList = ({ transactions }) => {
 	const pendingTransactions = transactions.filter(transaction => transaction.trust < 100);
-	const completedTransactions = transactions.filter(transaction => transaction.trust >= 100);
+	//Trust prop is not presently supplied so using !transaction.trust to show completed transactions
+	const completedTransactions = transactions.filter(transaction => !transaction.trust || transaction.trust >= 100);
 
 	return (
 		<div className='TransactionsList'>


### PR DESCRIPTION
### Description

Fixes regression where completed transactions stopped displaying
Fix will need to be removed when property transactions.trust is supported

### Issues fixed

None

### Checklist

- [x] `npm test` returns no warnings or errors.
