### PR TITLE
Run jest unit tests in band on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Run the tests configured in package.json.
       - run:
-          command: npm run test-ci -- --testResultsProcessor="jest-junit"
+          command: npm run test-ci -- --runInBand --testResultsProcessor="jest-junit"
           environment:
             JEST_JUNIT_OUTPUT: reports/junit/js-test-results.xml
 


### PR DESCRIPTION
### Description

Runs unit tests in serial mode, as otherwise Jest will try to allocate resources based on the specs of the entire CI machine instead of the specs of the container VM. See https://github.com/facebook/jest/issues/1524#issuecomment-262366820

### Issues fixed

None reported.

### Checklist

- [x] `npm test` returns no warnings or errors.
