### PR TITLE
Updating styles for ErrorList to match latest designs

### DIFF
--- a/src/components/ErrorList/Error.svg
+++ b/src/components/ErrorList/Error.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49.1 (51147) - http://www.bohemiancoding.com/sketch -->
+    <title>Icon/Error</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Symbols-for-export" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-31.000000, -33.000000)" id="Icon/Error">
+            <g transform="translate(31.000000, 33.000000)">
+                <g id="Page-1">
+                    <path d="M8,0 C3.582,0 0,3.582 0,8 C0,12.418 3.582,16 8,16 C12.418,16 16,12.418 16,8 C16,3.582 12.418,0 8,0" id="Fill-1" fill="#E24444"></path>
+                    <path d="M8.707,8 L11.353,5.354 C11.549,5.158 11.549,4.842 11.353,4.646 C11.158,4.451 10.842,4.451 10.646,4.646 L8,7.293 L5.353,4.646 C5.158,4.451 4.842,4.451 4.646,4.646 C4.451,4.842 4.451,5.158 4.646,5.354 L7.293,8 L4.646,10.646 C4.451,10.842 4.451,11.158 4.646,11.354 C4.744,11.451 4.872,11.5 5,11.5 C5.128,11.5 5.256,11.451 5.353,11.354 L8,8.707 L10.646,11.354 C10.744,11.451 10.872,11.5 11,11.5 C11.128,11.5 11.256,11.451 11.353,11.354 C11.549,11.158 11.549,10.842 11.353,10.646 L8.707,8 Z" id="Fill-3" fill="#FFFFFF"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/ErrorList/ErrorList.css
+++ b/src/components/ErrorList/ErrorList.css
@@ -1,9 +1,13 @@
 .ErrorList ul {
-	margin-top: -16px;
-	margin-bottom: 32px;
-	padding-left: 18px;
+	list-style: none;
+	margin-top: -28px;
+	margin-bottom: 16px;
 }
 
 .ErrorList li {
-	margin-bottom: 8px;
+	font-size: 14px;
+	line-height: 24px;
+	padding-left: 24px;
+	background: url(Error.svg) no-repeat left 4px;
+	background-size: 16px;
 }

--- a/src/components/ErrorList/ErrorList.js
+++ b/src/components/ErrorList/ErrorList.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import './ErrorList.css';
 
 const ErrorList = ({ errors }) => (
-	<div className='base'>
+	<div className='ErrorList'>
 		{errors.length > 0 &&
 		<ul>
 			{errors.map((item, index) => (

--- a/src/components/ErrorList/ErrorList.story.js
+++ b/src/components/ErrorList/ErrorList.story.js
@@ -8,7 +8,7 @@ storiesOf('ErrorList', module)
 
 	.addDecorator((story, context) => withInfo(ErrorList.description)(story)(context))
 
-	.add('with errors', () => (
+	.add('base', () => (
 		<ErrorList
 			errors={['Value is too long',
 				'Must start with 0x',

--- a/src/components/TextInput/TextInput.css
+++ b/src/components/TextInput/TextInput.css
@@ -21,11 +21,11 @@
 	transition: background 0.3s ease, border-color 0.3s ease;
 }
 
+.TextInput.is-invalid input {
+	border-color: #E24444;
+}
+
 .TextInput input:focus {
 	border-color: #fff;
 	outline: 0;
-}
-
-.TextInput.is-invalid input {
-	background-color: rgba(255, 0, 0, 0.3);
 }


### PR DESCRIPTION
### Description

Adding styles to the previously half-completed error messages for address input.

### Issues fixed

Fixes #91 

### Checklist

- [x] `npm test` returns no warnings or errors.
