### PR TITLE
Feature/test scripts coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,19 @@
     "stylelint": "^9.1.1",
     "stylelint-config-recommended": "^2.1.0"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}",
+      "!**/node_modules/**",
+      "!**/lib/**",
+      "!**/utils/**",
+	  "!**/coverage/**",
+	  "!**/src/components/**",
+	  "!**/src/containers/**",
+	  "!**/src/*",
+	  "!**/src/reducers/index.js"
+    ]
+  },
   "eslintIgnore": [
     "src/lib/superstruct/index.js"
   ]

--- a/src/reducers/slices/settings.test.js
+++ b/src/reducers/slices/settings.test.js
@@ -1,0 +1,70 @@
+import settingsReducer from './settings.js';
+import * as types from '../../constants/actionTypes';
+
+describe('settings reducer', () => {
+	it('it should add the token address', () => {
+		const initialState = {
+			tokenAddress: '',
+			trustLevel: 1,
+			walletAddress: '',
+		};
+		const newPayload = {
+			tokenAddress: '0x987654321',
+		};
+		const action = {
+			type: types.ADD_TOKEN,
+			payload: newPayload,
+		};
+		const expectedState = {
+			tokenAddress: '0x987654321',
+			trustLevel: 1,
+			walletAddress: '',
+		};
+
+		expect(settingsReducer(initialState, action)).toEqual(expectedState);
+	});
+
+	it('it should set the trust level', () => {
+		const initialState = {
+			tokenAddress: '',
+			trustLevel: 1,
+			walletAddress: '',
+		};
+		const newPayload = {
+			trustLevel: 5,
+		};
+		const action = {
+			type: types.SET_TRUST,
+			payload: newPayload,
+		};
+		const expectedState = {
+			tokenAddress: '',
+			trustLevel: 5,
+			walletAddress: '',
+		};
+
+		expect(settingsReducer(initialState, action)).toEqual(expectedState);
+	});
+
+	it('it should add the wallet address', () => {
+		const initialState = {
+			tokenAddress: '',
+			trustLevel: 1,
+			walletAddress: '',
+		};
+		const newPayload = {
+			walletAddress: '0x987654321',
+		};
+		const action = {
+			type: types.ADD_WALLET,
+			payload: newPayload,
+		};
+		const expectedState = {
+			tokenAddress: '',
+			trustLevel: 1,
+			walletAddress: '0x987654321',
+		};
+
+		expect(settingsReducer(initialState, action)).toEqual(expectedState);
+	});
+});


### PR DESCRIPTION
### Description

Adds config files for running `npm run test-watch -- --coverage` to get a Jest coverage of unit testing. Now it shows where there are gaps for us to fill in with proper unit testing.

### Issues fixed

This addresses #83 as much as I can do for the time being. I think anything else requires someone that 100% understands the actions/reducers/APIs.

### Checklist

- [ ] `npm test` returns no warnings or errors.
