### PR TITLE
Fixing bug where SettingsDrawer overlay only went as far as the viewa…

### DIFF
--- a/src/components/SettingsDrawer/SettingsDrawer.css
+++ b/src/components/SettingsDrawer/SettingsDrawer.css
@@ -5,7 +5,7 @@
 	left: 0;
 	opacity: 0.5;
 	pointer-events: none;
-	position: absolute;
+	position: fixed;
 	transition: background 1s;
 	top: 0;
 	right: 0;


### PR DESCRIPTION
…ble viewport

### Description

Fixed bug where, when the SettingsDrawers is open and the overlay covers the rest of the content, instead of the overlay only covering the viewable viewport and not the rest of the page, it now does.

### Issues fixed

N/A

### Checklist

- [X] `npm test` returns no warnings or errors.
