### PR TITLE
Add recommended eslint rules for things Prettier doesn't pick up

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,13 @@
 		"es6": true,
 		"jest": true
 	},
-	"plugins": ["prettier"],
-	"extends": ["prettier", "prettier/react"],
+	"plugins": ["react", "prettier"],
+	"extends": [
+		"eslint:recommended",
+		"plugin:react/recommended",
+		"prettier",
+		"prettier/react"
+	],
 	"rules": {
 		"prettier/prettier": "error",
 		"linebreak-style": ["error", "unix"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5799,9 +5799,10 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
-      "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "dev": true,
       "requires": {
         "doctrine": "2.1.0",
         "has": "1.0.1",
@@ -5813,6 +5814,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
           "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "dev": true,
           "requires": {
             "array-includes": "3.0.3"
           }
@@ -13548,6 +13550,17 @@
             }
           }
         },
+        "eslint-plugin-react": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
+          "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
+          "requires": {
+            "doctrine": "2.1.0",
+            "has": "1.0.1",
+            "jsx-ast-utils": "2.0.1",
+            "prop-types": "15.6.1"
+          }
+        },
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
@@ -13560,6 +13573,14 @@
           "requires": {
             "argparse": "1.0.10",
             "esprima": "4.0.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "requires": {
+            "array-includes": "3.0.3"
           }
         },
         "promise": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^4.18.2",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.7.0",
     "jest-junit": "^3.6.0",
     "prettier": "^1.11.1",
     "react-test-renderer": "^16.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -19,10 +19,6 @@ class App extends React.Component {
 		};
 	}
 
-	tempLog(e) {
-		console.log(e); // eslint-disable-line
-	}
-
 	toggleSettingsDrawer() {
 		this.setState(prevState => {
 			return { settingsDrawerIsOpen: !prevState.settingsDrawerIsOpen };


### PR DESCRIPTION
### Description

Prettier doesn't pick up things like undeclared variables, so add in eslint/recommended rules to cover those.

### Issues fixed

None.

### Checklist

- [x] `npm test` returns no warnings or errors.
