### PR TITLE
Fix junk tokens with non-erc20 transactions breaking the app

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -26,9 +26,12 @@ export const addTransaction = data => {
 export const receiveTransactions = transactions => (dispatch, getState) => {
 	const { settings, transactions: knownTxs } = getState();
 
-	const { trustLevel } = settings;
+	const { trustLevel, tokenAddress } = settings;
 
 	transactions.forEach(async transaction => {
+		// Ignore if it's not our token.
+		if (transaction.address !== tokenAddress) return;
+
 		// If we already know about it, skip if it's already exceeded the confirmation target.
 		const transactionIsKnown = !!knownTxs[transaction.transactionHash];
 		if (
@@ -46,7 +49,6 @@ export const receiveTransactions = transactions => (dispatch, getState) => {
 
 export const getAllTransactions = () => (dispatch, getState) => {
 	const { walletAddress } = getState().settings;
-
 	transactionApi
 		.getTransactions({ walletAddress })
 		.then(transactions => {

--- a/src/index.js
+++ b/src/index.js
@@ -18,14 +18,19 @@ import {
 	addWallet,
 } from './actions';
 
+// Default settings
 store.dispatch(addWallet(env.REACT_APP_WALLET_ADDRESS));
 store.dispatch(addToken(env.REACT_APP_CONTRACT_ADDRESS));
-store.dispatch(addTokenMetadata(env.REACT_APP_CONTRACT_ADDRESS));
-
 store.dispatch(setTrust(6));
 
+// Preload token data for contract
+store.dispatch(addTokenMetadata(env.REACT_APP_CONTRACT_ADDRESS));
+
+// Fetch transactions
 store.dispatch(getPendingTransactions());
 store.dispatch(getAllTransactions());
+
+// Set up polling for transactions
 store.dispatch(enableTransactionPolling());
 
 if (env.REACT_APP_SIMULATED_TRANSACTIONS) {


### PR DESCRIPTION
### Description

Ignores token transactions that aren't from the configured contract address.

### Issues fixed

Fixes #151 

### Checklist

- [x] `npm test` returns no warnings or errors.
