### PR TITLE
Update yaab to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17297,9 +17297,9 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yaab": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yaab/-/yaab-0.1.0.tgz",
-      "integrity": "sha512-yrk+myf8u9MEqgYCo3uOw4Oam2AxjWApk0YuHjB/Jp3EghHxsJwQ4BzsY/7zBJ0q1n2hmzIIdjat0ABlmekE+w=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/yaab/-/yaab-0.2.0.tgz",
+      "integrity": "sha512-0HnoqGpuQinIHYz66tqbPg4rNat2VPln7G2RUZ2k8nbWmq66fEZMwXP3QRnb6vJsl656pbs7HcikYJzDH5dvfQ=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "superstruct": "^0.5.1",
-    "yaab": "0.1.0"
+    "yaab": "^0.2.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
### Description

Updates yaab to 0.2.0 which adds pre-transpiled code, as `npm run build` doesn't compile `node_modules/`.

https://github.com/dan1elhughes/yaab/commit/503338095891b85c6bc39edbd2efafd0980e241d

### Issues fixed

Fixes #152 

### Checklist

- [x] `npm test` returns no warnings or errors.
