### PR TITLE
Settings saved in local storage

### DIFF
--- a/src/containers/SettingsDrawer/SettingsDrawer.js
+++ b/src/containers/SettingsDrawer/SettingsDrawer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import localStore from '../../utils/localStore';
 
 import bindMethods from 'yaab';
 
@@ -27,6 +28,7 @@ const mapDispatchToProps = dispatch => ({
 		dispatch(setTrust(trustLevel));
 		dispatch(clearTransactions());
 		dispatch(getAllTransactions());
+		localStore.setItems({ walletAddress, trustLevel });
 	},
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import store from './store';
 import DevTools from './containers/DevTools/DevTools';
 import env from './utils/environment';
+import localStore from './utils/localStore';
 
 import {
 	getAllTransactions,
@@ -19,9 +20,13 @@ import {
 } from './actions';
 
 // Default settings
-store.dispatch(addWallet(env.REACT_APP_WALLET_ADDRESS));
-store.dispatch(addToken(env.REACT_APP_CONTRACT_ADDRESS));
-store.dispatch(setTrust(6));
+store.dispatch(
+	addWallet(localStore.getItem('walletAddress') || env.REACT_APP_WALLET_ADDRESS)
+);
+store.dispatch(
+	addToken(localStore.getItem('tokenAddress') || env.REACT_APP_CONTRACT_ADDRESS)
+);
+store.dispatch(setTrust(localStore.getItem('trustLevel') || 6));
 
 // Preload token data for contract
 store.dispatch(addTokenMetadata(env.REACT_APP_CONTRACT_ADDRESS));

--- a/src/utils/localStore.js
+++ b/src/utils/localStore.js
@@ -1,0 +1,20 @@
+class LocalStore {
+	getItem(key) {
+		let value = localStorage.getItem(key);
+		try {
+			return JSON.parse(value);
+		} catch (e) {
+			return value;
+		}
+	}
+	setItem(key, value) {
+		localStorage.setItem(key, JSON.stringify(value));
+	}
+	setItems(object) {
+		for (let key in object) {
+			this.setItem(key, object[key]);
+		}
+	}
+}
+
+export default new LocalStore();


### PR DESCRIPTION
### Description

adding in new utility localStore a wrapper around localStorage. settings are now retrieved from localStore, if no settings found then falls back to env variables. any changes made in the settings drawer will save through localStore into the local storage.

### Issues fixed

Fixes #161 

### Checklist

- [*] `npm test` returns no warnings or errors.
